### PR TITLE
Add kaspaterminal URL handling for NFC payments

### DIFF
--- a/lib/kaspa/types.dart
+++ b/lib/kaspa/types.dart
@@ -3,4 +3,5 @@ export 'types/address_balance.dart';
 export 'types/address_prefix.dart';
 export 'types/amount.dart';
 export 'types/kaspa_uri.dart';
+export 'types/kaspa_terminal_uri.dart';
 export 'types/token_info.dart';

--- a/lib/kaspa/types/kaspa_terminal_uri.dart
+++ b/lib/kaspa/types/kaspa_terminal_uri.dart
@@ -1,0 +1,48 @@
+import 'package:decimal/decimal.dart';
+
+import 'address.dart';
+import 'address_prefix.dart';
+import 'amount.dart';
+import 'kaspa_uri.dart';
+
+/// Utility for parsing kaspaterminal URIs produced by NFC terminals.
+///
+/// Expected format: `kaspaterminal://address/<kaspa address>/payment/<amount>`.
+/// The amount is expressed in KAS (decimal) and will be converted to [Amount].
+class KaspaTerminalUri {
+  /// Tries to parse [uri] and return a [KaspaUri] with the embedded
+  /// address and amount. Returns `null` if the format is invalid.
+  static KaspaUri? tryParse(
+    String uri, {
+    AddressPrefix prefix = AddressPrefix.unknown,
+  }) {
+    final parsed = Uri.tryParse(uri);
+    if (parsed == null || parsed.scheme != 'kaspaterminal') {
+      return null;
+    }
+
+    final segments = parsed.pathSegments;
+    if (segments.length < 4) {
+      return null;
+    }
+    if (segments[0] != 'address' || segments[2] != 'payment') {
+      return null;
+    }
+
+    final addressStr = Uri.decodeComponent(segments[1]);
+    final address = Address.tryParse(addressStr, expectedPrefix: prefix);
+    if (address == null) {
+      return null;
+    }
+
+    Amount? amount;
+    final amountStr = Uri.decodeComponent(segments[3]);
+    final amountDec = Decimal.tryParse(amountStr);
+    if (amountDec != null) {
+      amount = Amount.value(amountDec);
+    }
+
+    return KaspaUri(address: address, amount: amount);
+  }
+}
+

--- a/lib/wallet_home/wallet_home.dart
+++ b/lib/wallet_home/wallet_home.dart
@@ -39,17 +39,23 @@ class WalletHome extends HookConsumerWidget {
     ref.watch(_walletWatcherProvider);
 
     useEffect(() {
-      final notifier = ref.read(appLinkProvider.notifier);
-      return notifier.addListener((appLink) {
+      void handle(String? appLink) {
         if (appLink == null) {
           return;
         }
-        final walletAuth = ref.read(walletAuthNotifierProvider);
-        if (walletAuth == null || walletAuth.walletIsLocked) {
+
+        final walletAuth = ref.read(walletAuthProvider);
+        if (walletAuth.isLocked) {
           return;
         }
+
         final prefix = ref.read(addressPrefixProvider);
-        final uri = KaspaUri.tryParse(appLink, prefix: prefix);
+        KaspaUri? uri;
+        if (appLink.startsWith('kaspaterminal://')) {
+          uri = KaspaTerminalUri.tryParse(appLink, prefix: prefix);
+        } else {
+          uri = KaspaUri.tryParse(appLink, prefix: prefix);
+        }
 
         Future.microtask(() {
           if (uri == null) {
@@ -59,9 +65,25 @@ class WalletHome extends HookConsumerWidget {
 
           UIUtil.showSendFlow(context, ref: ref, uri: uri);
 
-          notifier.state = null;
+          ref.read(appLinkProvider.notifier).state = null;
         });
-      }, fireImmediately: true);
+      }
+
+      final sub1 = ref.listen<String?>(
+        appLinkProvider,
+        (_, next) => handle(next),
+        fireImmediately: true,
+      );
+      final sub2 = ref.listen(
+        walletAuthProvider.select((auth) => auth.isLocked),
+        (_, __) => handle(ref.read(appLinkProvider)),
+        fireImmediately: true,
+      );
+
+      return () {
+        sub1.close();
+        sub2.close();
+      };
     }, const []);
 
     return Column(

--- a/test/kaspa_uri_test.dart
+++ b/test/kaspa_uri_test.dart
@@ -87,4 +87,17 @@ void main() {
     expect(uri.message, equals(message));
     expect(uri.others, isEmpty);
   });
+
+  test('Kaspaterminal uri with address and amount', () {
+    final amount = Decimal.parse('1.234');
+    final uriStr =
+        'kaspaterminal://address/$address/payment/${amount.toString()}';
+    final uri = KaspaTerminalUri.tryParse(uriStr);
+
+    expect(uri, isNotNull);
+    expect(uri!.address.toString(), equals(address));
+    expect(uri.amount, equals(Amount.value(amount)));
+    expect(uri.label, isNull);
+    expect(uri.message, isNull);
+  });
 }


### PR DESCRIPTION
## Summary
- parse `kaspaterminal://` URIs into address and amount
- react to kaspaterminal links on wallet home and open send flow after unlock
- cover new parser with unit test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f43f92c708332bd63df730a363adf